### PR TITLE
Use WSL `--exec` flag when invoking git in WSL mode

### DIFF
--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -552,6 +552,7 @@ fn git_command(target: &RepoTarget) -> Command {
                 .arg(distro)
                 .arg("--cd")
                 .arg(&target.root_path)
+                .arg("--exec")
                 .arg("git");
             command
         }


### PR DESCRIPTION
### Motivation
- Ensure the `git` process is executed correctly when running commands inside a WSL distro by using WSL's `--exec` flag so arguments and the working directory are handled as intended.

### Description
- Add `.arg("--exec")` before the `git` argument in the WSL branch of `git_command` so the code invokes `wsl[-.exe] -d <distro> --cd <path> --exec git` instead of passing `git` as a bare argument.

### Testing
- Ran `cargo build` and `cargo test` and the build and automated test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44a2d3c4c832089cf69af5618410a)